### PR TITLE
Allow scaling down to 0 free agents

### DIFF
--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	logLevel          = flag.String("log-level", "info", "Log level (trace, debug, info, warn, error, fatal, panic).")
-	min               = flag.Int("min", 1, "Minimum number of free agents to keep alive. Minimum of 1.")
+	min               = flag.Int("min", 1, "Minimum number of free agents to keep alive. Minimum of 0.")
 	max               = flag.Int("max", 100, "Maximum number of agents allowed.")
 	rate              = flag.Duration("rate", 10*time.Second, "Duration to check the number of agents.")
 	scaleDownDelay    = flag.Duration("scale-down", 30*time.Second, "Wait time after scaling down to scale down again.")
@@ -109,8 +109,8 @@ func ValidateArgs() error {
 	if err != nil {
 		validationErrors = append(validationErrors, err.Error())
 	}
-	if *min < 1 {
-		validationErrors = append(validationErrors, "Min argument cannot be less than 1.")
+	if *min < 0 {
+		validationErrors = append(validationErrors, "Min argument cannot be less than 0.")
 	}
 	if *max <= *min {
 		validationErrors = append(validationErrors, "Max pods argument must be greater than the minimum.")


### PR DESCRIPTION
I am not sure what you think about this. I started using your autoscaler (only this morning but so far so good!) so many thanks for your work in creating it!

We have a pool of agents that are on a development cluster. The pool is basically for the "unstable" agent image that we are working on and is rarely used - only when a build targets it specifically to test it against the new agent build.

It would be nice to be able to scale this pool down to 0 and stateful sets DO support this. I don't see any reason why the autoscaler doesn't support it. I've looked at the code (although I don't know Go) and don't think it would be a problem but obviously you would know better...!

Thanks again for the autoscaler!